### PR TITLE
Fix for postgresql session store handles

### DIFF
--- a/lib/Apache/Session/Store/Postgres.pm
+++ b/lib/Apache/Session/Store/Postgres.pm
@@ -80,6 +80,7 @@ sub materialize {
     my $results = $self->{materialize_sth}->fetchrow_arrayref;
 
     if (!(defined $results)) {
+        $self->{materialize_sth}->finish;
         die "Object does not exist in the data store";
     }
 


### PR DESCRIPTION
This make sure that the materialize_sth gets finished if the "object does not exist" case is encountered.  without this, warnings will get emitted because an unfinished/open handle was destroyed.
